### PR TITLE
Add LangChain prompts and tech stack options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This project uses FastAPI + AI to match resumes with job descriptions using LLMs
 ## ✅ Features
 
 - FastAPI-based backend
-- LLM-powered JD generation (Gemini)
+- LLM-powered JD generation (Gemini + LangChain prompts)
+- Flexible JD generation accepting comma-separated tech stacks
 - Resume parsing & matching
 - Sentence-transformer embeddings
 - ChromaDB (local vector store)
@@ -23,6 +24,7 @@ app/
 ├── utils/        # Helpers: file parsers, validators
 ├── core/         # Config management
 ├── llm/          # LLM API wrappers (Gemini/OpenAI)
+├── prompts/      # Prompt templates for LangChain
 ├── services/     # Business logic (resume scoring etc.)
 ├── models/       # Pydantic schemas
 ├── db/           # Vector store clients (Chroma/FAISS)

--- a/app/llm/gemini_wrapper.py
+++ b/app/llm/gemini_wrapper.py
@@ -1,21 +1,21 @@
 """Wrapper utilities for interacting with the Gemini API."""
 
 import google.generativeai as genai
+from pathlib import Path
+from langchain.prompts import PromptTemplate
 
 from app.core.config import settings
 
 
 genai.configure(api_key=settings.GEMINI_API_KEY)
 
-PROMPT_TEMPLATE = (
-    "You are an HR assistant. Generate a detailed job description for the "
-    "role: {role}."
-)
+PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "jd_prompt.txt"
+JD_PROMPT_TEMPLATE = PromptTemplate.from_template(PROMPT_PATH.read_text())
 
 
-def generate_job_description(role: str) -> str:
+def generate_job_description(role: str, tech_stack: str | None = None) -> str:
     """Generate a job description for the given role using Gemini."""
-    prompt = PROMPT_TEMPLATE.format(role=role)
+    prompt = JD_PROMPT_TEMPLATE.format(role=role, tech_stack=tech_stack or "")
     model = genai.GenerativeModel("gemini-pro")
     response = model.generate_content(prompt)
     return response.text

--- a/app/llm/output_parser.py
+++ b/app/llm/output_parser.py
@@ -1,0 +1,9 @@
+"""Utilities to parse job description responses."""
+from typing import List, Dict
+
+
+def parse_jd_response(text: str) -> Dict[str, List[str]]:
+    """Naively parse bullet points from the JD text."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    bullets = [line.lstrip("*- ") for line in lines if line.startswith(('- ', '* '))]
+    return {"full_text": text, "bullet_points": bullets}

--- a/app/models/jd.py
+++ b/app/models/jd.py
@@ -5,3 +5,8 @@ class JDGenerationRequest(BaseModel):
     """Input model for JD generation via Gemini."""
 
     role: str = Field(..., example="Software Engineer")
+    tech_stack: str | None = Field(
+        None,
+        example="Python, FastAPI, PostgreSQL",
+        description="Comma separated list of required technologies",
+    )

--- a/app/prompts/jd_prompt.txt
+++ b/app/prompts/jd_prompt.txt
@@ -1,0 +1,3 @@
+You are an HR assistant. Generate a detailed job description for the role: {role}.
+If specific technologies are provided, incorporate them into the requirements: {tech_stack}.
+Return concise bullet points.

--- a/app/routes/jd.py
+++ b/app/routes/jd.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException
 from app.models.jd import JDGenerationRequest
 from app.utils.file_parser import extract_text_from_upload
 from app.llm.gemini_wrapper import generate_job_description
+from app.llm.output_parser import parse_jd_response
 
 router = APIRouter()
 
@@ -20,5 +21,6 @@ async def upload_jd(file: UploadFile = File(...)):
 @router.post("/generate")
 def generate_jd(payload: JDGenerationRequest):
     """Generate a JD using the Gemini API."""
-    jd_text = generate_job_description(payload.role)
-    return {"jd": jd_text}
+    jd_text = generate_job_description(payload.role, payload.tech_stack)
+    parsed = parse_jd_response(jd_text)
+    return {"jd": jd_text, "parsed": parsed}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ sentence-transformers = "^2.5.1"
 chromadb = "^0.4.22"
 google-generativeai = "^0.3.2"
 python-dotenv = "^1.0.1"
+langchain = "^0.1.14"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"


### PR DESCRIPTION
## Summary
- allow providing comma-separated tech stack when generating a JD
- manage JD prompt via LangChain using a new `prompts` folder
- add naive output parser to extract bullet points
- update JD route to return parsed output
- include `langchain` dependency in `pyproject.toml`
- update README with new features

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685285c8beb08329963e39a92cb31a55