### PR TITLE
Add resume upload API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project uses FastAPI + AI to match resumes with job descriptions using LLMs
 - FastAPI-based backend
 - LLM-powered JD generation (Gemini + LangChain prompts)
 - Flexible JD generation accepting comma-separated tech stacks
-- Resume parsing & matching
+- Single resume upload & parsing
 - Sentence-transformer embeddings
 - ChromaDB (local vector store)
 - Modular, scalable architecture (LLD + HLD ready)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,2 @@
+from .jd import JDGenerationRequest
+from .resume import ResumeMetadata

--- a/app/models/resume.py
+++ b/app/models/resume.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field, EmailStr
+
+
+class ResumeMetadata(BaseModel):
+    """Metadata accompanying an uploaded resume."""
+
+    candidate_name: str = Field(..., example="John Doe")
+    email: EmailStr | None = Field(
+        None,
+        example="john.doe@example.com",
+        description="Candidate contact email",
+    )
+    notes: str | None = Field(None, example="Referred by Alice")
+

--- a/app/routes/resume.py
+++ b/app/routes/resume.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends, Form
+
+from app.models.resume import ResumeMetadata
+from app.utils.file_parser import extract_text_from_upload
+
+router = APIRouter()
+
+
+async def _metadata_from_form(
+    candidate_name: str = Form(...),
+    email: str | None = Form(None),
+    notes: str | None = Form(None),
+) -> ResumeMetadata:
+    """Construct ResumeMetadata from multipart form fields."""
+
+    return ResumeMetadata(candidate_name=candidate_name, email=email, notes=notes)
+
+
+@router.post("/upload")
+async def upload_resume(
+    file: UploadFile = File(...),
+    metadata: ResumeMetadata = Depends(_metadata_from_form),
+):
+    """Upload a single resume and return parsed text."""
+    try:
+        text = await extract_text_from_upload(file)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"metadata": metadata.model_dump(), "text": text}

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings  # noqa: F401 - imported for side effects
 from app.core.logger import logger
 from app.routes import jd as jd_router
+from app.routes import resume as resume_router
 
 app = FastAPI(title="Recruitment AI RAG System", version="1.0")
 
@@ -18,6 +19,7 @@ app.add_middleware(
 logger.info("Application starting with CHROMA_DIR=%s", settings.CHROMA_DIR)
 
 app.include_router(jd_router.router, prefix="/jd", tags=["jd"])
+app.include_router(resume_router.router, prefix="/resume", tags=["resume"])
 
 
 @app.get("/", tags=["health"])


### PR DESCRIPTION
## Summary
- add Pydantic schema for resume metadata
- create resume upload endpoint
- wire new router and document feature

## Testing
- `pytest -q`
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_685298e002bc8329b75588fa9bf34ce4