### PR TITLE
Add Gemini remarks and email generation

### DIFF
--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,0 +1,11 @@
+"""Convenience exports for LLM utilities."""
+
+from .gemini_wrapper import generate_job_description, generate_candidate_remarks
+from .email_generator import generate_interview_email, generate_rejection_email
+
+__all__ = [
+    "generate_job_description",
+    "generate_candidate_remarks",
+    "generate_interview_email",
+    "generate_rejection_email",
+]

--- a/app/llm/email_generator.py
+++ b/app/llm/email_generator.py
@@ -1,0 +1,40 @@
+"""Utilities to generate candidate emails using Gemini."""
+
+from pathlib import Path
+
+import google.generativeai as genai
+from langchain.prompts import PromptTemplate
+
+from app.core.config import settings
+
+
+# Configure Gemini with the API key
+genai.configure(api_key=settings.GEMINI_API_KEY)
+
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+INTERVIEW_PROMPT = PromptTemplate.from_template(
+    (PROMPTS_DIR / "interview_email_prompt.txt").read_text()
+)
+
+REJECTION_PROMPT = PromptTemplate.from_template(
+    (PROMPTS_DIR / "rejection_email_prompt.txt").read_text()
+)
+
+
+def generate_interview_email(candidate_name: str, role: str) -> str:
+    """Generate an interview invitation email."""
+
+    prompt = INTERVIEW_PROMPT.format(candidate_name=candidate_name, role=role)
+    model = genai.GenerativeModel("gemini-pro")
+    response = model.generate_content(prompt)
+    return response.text.strip()
+
+
+def generate_rejection_email(candidate_name: str, role: str) -> str:
+    """Generate a rejection email."""
+
+    prompt = REJECTION_PROMPT.format(candidate_name=candidate_name, role=role)
+    model = genai.GenerativeModel("gemini-pro")
+    response = model.generate_content(prompt)
+    return response.text.strip()

--- a/app/llm/gemini_wrapper.py
+++ b/app/llm/gemini_wrapper.py
@@ -9,8 +9,15 @@ from app.core.config import settings
 
 genai.configure(api_key=settings.GEMINI_API_KEY)
 
-PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "jd_prompt.txt"
-JD_PROMPT_TEMPLATE = PromptTemplate.from_template(PROMPT_PATH.read_text())
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+JD_PROMPT_TEMPLATE = PromptTemplate.from_template(
+    (PROMPTS_DIR / "jd_prompt.txt").read_text()
+)
+
+REMARKS_PROMPT_TEMPLATE = PromptTemplate.from_template(
+    (PROMPTS_DIR / "remarks_prompt.txt").read_text()
+)
 
 
 def generate_job_description(role: str, tech_stack: str | None = None) -> str:
@@ -19,3 +26,15 @@ def generate_job_description(role: str, tech_stack: str | None = None) -> str:
     model = genai.GenerativeModel("gemini-pro")
     response = model.generate_content(prompt)
     return response.text
+
+
+def generate_candidate_remarks(missing: list[str], strong: list[str]) -> str:
+    """Generate a short remark highlighting missing and strong skills."""
+
+    prompt = REMARKS_PROMPT_TEMPLATE.format(
+        missing=", ".join(missing) if missing else "none",
+        strong=", ".join(strong) if strong else "none",
+    )
+    model = genai.GenerativeModel("gemini-pro")
+    response = model.generate_content(prompt)
+    return response.text.strip()

--- a/app/prompts/interview_email_prompt.txt
+++ b/app/prompts/interview_email_prompt.txt
@@ -1,0 +1,1 @@
+You are an HR assistant. Draft a short interview invitation email to {candidate_name} for the {role} position. Keep it concise and professional.

--- a/app/prompts/rejection_email_prompt.txt
+++ b/app/prompts/rejection_email_prompt.txt
@@ -1,0 +1,1 @@
+You are an HR assistant. Draft a short rejection email to {candidate_name} for the {role} position. Be polite and encourage them to apply again in the future.

--- a/app/prompts/remarks_prompt.txt
+++ b/app/prompts/remarks_prompt.txt
@@ -1,0 +1,4 @@
+You are an HR assistant. Summarize the candidate's profile in one short sentence.
+List the missing skills: {missing}.
+Mention the strong skills: {strong}.
+Respond in the format "Lacks X, Strong in Y."


### PR DESCRIPTION
## Summary
- add prompt templates for skill remarks and emails
- support Gemini-powered remarks in `gemini_wrapper`
- implement interview/rejection email generators
- expose new utilities in `app.llm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852aae904b48329aa738b987949ae82