### PR TITLE
Add RAG matching endpoint

### DIFF
--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,11 +1,16 @@
 """Convenience exports for LLM utilities."""
 
-from .gemini_wrapper import generate_job_description, generate_candidate_remarks
+from .gemini_wrapper import (
+    generate_job_description,
+    generate_candidate_remarks,
+    assess_resume_with_jd,
+)
 from .email_generator import generate_interview_email, generate_rejection_email
 
 __all__ = [
     "generate_job_description",
     "generate_candidate_remarks",
+    "assess_resume_with_jd",
     "generate_interview_email",
     "generate_rejection_email",
 ]

--- a/app/llm/gemini_wrapper.py
+++ b/app/llm/gemini_wrapper.py
@@ -19,6 +19,10 @@ REMARKS_PROMPT_TEMPLATE = PromptTemplate.from_template(
     (PROMPTS_DIR / "remarks_prompt.txt").read_text()
 )
 
+MATCH_PROMPT_TEMPLATE = PromptTemplate.from_template(
+    (PROMPTS_DIR / "matching_prompt.txt").read_text()
+)
+
 
 def generate_job_description(role: str, tech_stack: str | None = None) -> str:
     """Generate a job description for the given role using Gemini."""
@@ -37,4 +41,16 @@ def generate_candidate_remarks(missing: list[str], strong: list[str]) -> str:
     )
     model = genai.GenerativeModel("gemini-pro")
     response = model.generate_content(prompt)
+    return response.text.strip()
+
+
+def assess_resume_with_jd(jd: str, resume: str, *, top_p: float = 0.8) -> str:
+    """Evaluate a resume against a JD and return a short summary."""
+
+    prompt = MATCH_PROMPT_TEMPLATE.format(jd=jd, resume=resume)
+    model = genai.GenerativeModel("gemini-pro")
+    response = model.generate_content(
+        prompt,
+        generation_config={"top_p": top_p},
+    )
     return response.text.strip()

--- a/app/prompts/matching_prompt.txt
+++ b/app/prompts/matching_prompt.txt
@@ -1,0 +1,9 @@
+You are a professional recruiter. Use the following job description and resume to evaluate the candidate's fit.
+Provide concise bullet points describing strengths and gaps.
+
+Job Description:
+{jd}
+
+Resume:
+{resume}
+

--- a/app/routes/resume.py
+++ b/app/routes/resume.py
@@ -1,5 +1,10 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends, Form
 
+from app.db.chroma_store import get_collection
+from app.llm import assess_resume_with_jd
+from app.services.embedding import embed_text
+from app.services.matching import cosine_score
+
 from app.models.resume import ResumeMetadata
 from app.utils.file_parser import extract_text_from_upload
 
@@ -20,10 +25,44 @@ async def _metadata_from_form(
 async def upload_resume(
     file: UploadFile = File(...),
     metadata: ResumeMetadata = Depends(_metadata_from_form),
+    jd_file: UploadFile | None = File(None),
+    jd_text: str | None = Form(None),
+    top_k: int = Form(1),
+    top_p: float = Form(0.8),
 ):
     """Upload a single resume and return parsed text."""
     try:
-        text = await extract_text_from_upload(file)
+        resume_text = await extract_text_from_upload(file)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    return {"metadata": metadata.model_dump(), "text": text}
+
+    resume_embedding = embed_text(resume_text)
+    response = {"metadata": metadata.model_dump(), "text": resume_text}
+
+    jd_source = None
+    if jd_file is not None:
+        try:
+            jd_source = await extract_text_from_upload(jd_file)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    elif jd_text:
+        jd_source = jd_text
+
+    if jd_source:
+        jd_embedding = embed_text(jd_source)
+        score = cosine_score(resume_embedding, jd_embedding)
+
+        collection = get_collection("resumes")
+        doc_id = metadata.candidate_name
+        collection.add(documents=[resume_text], embeddings=[resume_embedding], ids=[doc_id])
+        results = collection.query(query_embeddings=[jd_embedding], n_results=top_k)
+        retrieved = "\n".join(" ".join(d) for d in results.get("documents", []))
+
+        summary = assess_resume_with_jd(jd_source, retrieved or resume_text, top_p=top_p)
+
+        response.update({
+            "jd": jd_source,
+            "similarity": score,
+            "analysis": summary,
+        })
+    return response


### PR DESCRIPTION
## Summary
- evaluate resumes against optional job descriptions
- connect embeddings and ChromaDB search
- supply new Gemini utility for resume+JD assessment
- expose top_k and top_p parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b51e805883299f0e9037124c0dd9