### PR TITLE
Add JD generation web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 🚀 Recruitment AI RAG (Production-Ready Setup)
+# Recruitment AI RAG (Production-Ready Setup)
 
-This project uses FastAPI + AI to match resumes with job descriptions using LLMs and vector similarity.
+This project uses FastAPI and AI to match resumes with job descriptions using LLMs and vector similarity.
 
 ---
 
-## ✅ Features
+## Features
 
 - FastAPI-based backend
 - LLM-powered JD generation (Gemini + LangChain prompts)
@@ -18,7 +18,7 @@ This project uses FastAPI + AI to match resumes with job descriptions using LLMs
 
 ---
 
-## 📁 Folder Structure
+## Folder Structure
 
 ```
 app/
@@ -38,7 +38,7 @@ examples/         # Sample JD/resume files
 
 ---
 
-## ⚙️ Setup Instructions
+## Setup Instructions
 
 ### 1. Install Poetry (if not already)
 
@@ -72,7 +72,7 @@ uvicorn main:app --reload
 
 ---
 
-## 🔐 .env File
+## .env File
 
 ```env
 GEMINI_API_KEY=your_gemini_api_key
@@ -81,7 +81,7 @@ CHROMA_DIR=.chromadb
 
 ---
 
-## 🧪 Run Tests
+## Run Tests
 
 ```bash
 pytest
@@ -89,13 +89,17 @@ pytest
 
 ---
 
-## 🛠️ Roadmap (Phases)
+## Roadmap (Phases)
 
-- ✅ Project Setup 
-- 🔜 Single Resume Parsing + JD Matching
-- 🔜 Score + Remarks + Skill Gap
-- 🔜 Email Generation
-- 🔜 Frontend with Jinja2
-- 🔜 Deployment (Docker/GitHub Actions)
+- Project Setup
+- Single Resume Parsing + JD Matching
+- Score + Remarks + Skill Gap
+- Email Generation
+- Frontend with Jinja2
+- Deployment (Docker/GitHub Actions)
+
+### Web Interface
+
+The application exposes simple HTML forms rendered via Jinja2 templates. Visit `/web/resume` to analyze resumes and `/web/jd` to generate job descriptions interactively.
 
 ---

--- a/app/templates/jd_form.html
+++ b/app/templates/jd_form.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block title %}Generate Job Description{% endblock %}
+{% block content %}
+<h2>Generate Job Description</h2>
+<form action="/web/jd" method="post">
+    <div class="field">
+        <label for="job_title">Job Title</label>
+        <input type="text" id="job_title" name="job_title" required />
+    </div>
+    <div class="field">
+        <label for="year_experience">Years of Experience</label>
+        <input type="number" step="0.1" id="year_experience" name="year_experience" required />
+    </div>
+    <div class="field">
+        <label for="tech_stack_must_have">Must Have Technologies</label>
+        <input type="text" id="tech_stack_must_have" name="tech_stack_must_have" />
+    </div>
+    <div class="field">
+        <label for="good_to_have">Good To Have Technologies</label>
+        <input type="text" id="good_to_have" name="good_to_have" />
+    </div>
+    <div class="field">
+        <label for="company_name">Company Name</label>
+        <input type="text" id="company_name" name="company_name" />
+    </div>
+    <div class="field">
+        <label for="employment_type">Employment Type</label>
+        <input type="text" id="employment_type" name="employment_type" required />
+    </div>
+    <div class="field">
+        <label for="industry">Industry</label>
+        <input type="text" id="industry" name="industry" required />
+    </div>
+    <div class="field">
+        <label for="location">Location</label>
+        <input type="text" id="location" name="location" required />
+    </div>
+    <button class="btn" type="submit">Generate</button>
+</form>
+{% endblock %}

--- a/app/templates/jd_results.html
+++ b/app/templates/jd_results.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}JD Results{% endblock %}
+{% block content %}
+<h2>Generated Job Description</h2>
+<pre>{{ jd }}</pre>
+{% if parsed.bullet_points %}
+    <h3>Key Points</h3>
+    <ul>
+        {% for point in parsed.bullet_points %}
+        <li>{{ point }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Jinja2 templates for a JD form and results
- expose `/web/jd` endpoints to generate JDs via the browser
- document the new web interface and remove icons from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543c7bbbb083298ca9657429eb8ada